### PR TITLE
Abs path

### DIFF
--- a/pages/nodejs.vue
+++ b/pages/nodejs.vue
@@ -13,7 +13,7 @@
         powers the <nuxt-link to="/download">browser extension</nuxt-link> and
         <nuxt-link to="/api">APIs</nuxt-link>. The project is largely community
         driven, upstream
-        <nuxt-link to="docs/dev">contributions</nuxt-link>
+        <nuxt-link to="/docs/dev/contributing">contributions</nuxt-link>
         are encouraged.
       </p>
 


### PR DESCRIPTION
<https://www.wappalyzer.com/nodejs>
> The project is largely community driven, upstream [contributions](https://www.wappalyzer.com/docs/dev) are encouraged.

[`docs/dev`](https://www.wappalyzer.com/docs/dev) -> [`/docs/dev/contributing`](https://www.wappalyzer.com/docs/dev/contributing)