### PR TITLE
Add `contain` property to `v-img` component in TechnologyIcon.vue

### DIFF
--- a/components/TechnologyIcon.vue
+++ b/components/TechnologyIcon.vue
@@ -4,6 +4,7 @@
       <v-img
         :src="`/images/icons/${icon}`"
         class="d-inline-block"
+        contain
         max-height="16"
         max-width="16"
       />


### PR DESCRIPTION
The heights and widths of some icons (such as [`CloudFlare.svg`](https://www.wappalyzer.com/images/icons/CloudFlare.svg), [`Fastly.svg`](https://www.wappalyzer.com/images/icons/Fastly.svg)) do not equal. These images are cropped incorrectly without `contain` properties.
#### Examples pages
- <https://www.wappalyzer.com/technologies/cdn/cloudflare>
- <https://www.wappalyzer.com/technologies/cdn/fastly>

---
Reference: <https://vuetifyjs.com/components/images/>
> ## API
> ### Props
> #### Name
> `contain`
> #### Type
> `boolean`
> #### Default
> `false`
> #### Description
> Prevents the image from being cropped if it doesn't fit