### PR TITLE
Update specification page

### DIFF
--- a/pages/docs/dev/specification.vue
+++ b/pages/docs/dev/specification.vue
@@ -25,7 +25,7 @@
           href="https://github.com/aliasio/wappalyzer/blob/master/src/apps.json"
           target="_blank"
         >
-          <code>src/apps.jon</code> </a
+          <code>src/apps.json</code> </a
         >. The following is an example of an application fingerprint.
       </p>
 

--- a/pages/docs/dev/specification.vue
+++ b/pages/docs/dev/specification.vue
@@ -175,9 +175,16 @@
               <td>String | Array</td>
               <td>
                 The presence of one application can imply the presence of
-                another, e.g. WordpPress means PHP is also in use. "PHP"
-                excludes String | Array Opposite of implies. The presence of one
-                application can exclude the presence of another.
+                another, e.g. WordpPress means PHP is also in use.
+              </td>
+              <td><code>"PHP"</code></td>
+            </tr>
+            <tr>
+              <td><code>excludes</code></td>
+              <td>String | Array</td>
+              <td>
+                Opposite of implies. The presence of one application can 
+                exclude the presence of another.
               </td>
               <td><code>"Apache"</code></td>
             </tr>


### PR DESCRIPTION
Fixes some minor errors on the dev/specification page.

- Typo in filename near top `apps.jon` -> `apps.json`.
- Splits implies and excludes into their own rows in the table. Before exclude was in the description for implies.